### PR TITLE
Fix aborting manual tasks not allowing to restart them.

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -545,7 +545,7 @@ class Game {
         if (!machine.unlocked) return false
         //---
         if (machine.status != 'paused') return false
-        if (machine.machienId != 'manual' && machine.count <= 0) return false
+        if (machine.machineId != 'manual' && machine.count <= 0) return false
         //---
         return true
     }


### PR DESCRIPTION
The check for whether a machine can start running or not had a special case to allow machines with the `manual` id to always start; however, that didn't work because the special case was checking the wrong property as a result of a typo in the code. This is now fixed to check the correct property.